### PR TITLE
Add admin controls for academic weeks settings

### DIFF
--- a/client/pages/AdminDashboard.tsx
+++ b/client/pages/AdminDashboard.tsx
@@ -38,6 +38,7 @@ import {
   deleteTeacher,
   subjects,
   getCurrentVisionBoardData,
+  updateWeeksSettings,
 } from "@shared/data";
 import { Admin, Teacher, Subject } from "@shared/types";
 import { cn } from "@/lib/utils";
@@ -67,6 +68,8 @@ export default function AdminDashboard() {
   });
   const navigate = useNavigate();
   const [helpCta] = useContent("home.helpCta");
+  const [totalWeeksInput, setTotalWeeksInput] = useState<number>(() => getCurrentVisionBoardData().totalWeeks);
+  const [currentWeekInput, setCurrentWeekInput] = useState<number>(() => getCurrentVisionBoardData().currentWeek);
 
   useEffect(() => {
     const adminData = localStorage.getItem("currentAdmin");
@@ -321,6 +324,62 @@ export default function AdminDashboard() {
             </CardContent>
           </Card>
         </div>
+
+        {/* Academic Weeks Settings */}
+        <Card className="mb-6">
+          <CardHeader>
+            <CardTitle className="text-orange-700">Academic Weeks Settings</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 items-end">
+              <div>
+                <Label htmlFor="total-weeks">Total Weeks (per year)</Label>
+                <Input
+                  id="total-weeks"
+                  type="number"
+                  min={1}
+                  value={totalWeeksInput}
+                  onChange={(e) => {
+                    const val = Math.max(1, Math.floor(Number(e.target.value) || 0));
+                    setTotalWeeksInput(val);
+                    if (currentWeekInput > val) setCurrentWeekInput(val);
+                  }}
+                  placeholder="Enter total number of weeks"
+                />
+              </div>
+              <div>
+                <Label htmlFor="current-week">Current Week</Label>
+                <Input
+                  id="current-week"
+                  type="number"
+                  min={1}
+                  max={totalWeeksInput}
+                  value={currentWeekInput}
+                  onChange={(e) => {
+                    const val = Math.floor(Number(e.target.value) || 1);
+                    setCurrentWeekInput(Math.min(Math.max(1, val), totalWeeksInput));
+                  }}
+                  placeholder="Enter current week"
+                />
+              </div>
+              <div className="flex gap-2">
+                <Button
+                  className="bg-orange-600 hover:bg-orange-700 text-white"
+                  onClick={() => {
+                    const total = Math.max(1, Math.floor(totalWeeksInput || 0));
+                    const current = Math.min(Math.max(1, Math.floor(currentWeekInput || 1)), total);
+                    updateWeeksSettings(current, total);
+                    setTotalWeeksInput(total);
+                    setCurrentWeekInput(current);
+                    showFeedback(`Saved: total weeks ${total}, current week ${current}`);
+                  }}
+                >
+                  Save Settings
+                </Button>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
 
         {/* Teacher Management */}
         <Card>

--- a/client/pages/AdminDashboard.tsx
+++ b/client/pages/AdminDashboard.tsx
@@ -68,8 +68,12 @@ export default function AdminDashboard() {
   });
   const navigate = useNavigate();
   const [helpCta] = useContent("home.helpCta");
-  const [totalWeeksInput, setTotalWeeksInput] = useState<number>(() => getCurrentVisionBoardData().totalWeeks);
-  const [currentWeekInput, setCurrentWeekInput] = useState<number>(() => getCurrentVisionBoardData().currentWeek);
+  const [totalWeeksInput, setTotalWeeksInput] = useState<number>(
+    () => getCurrentVisionBoardData().totalWeeks,
+  );
+  const [currentWeekInput, setCurrentWeekInput] = useState<number>(
+    () => getCurrentVisionBoardData().currentWeek,
+  );
 
   useEffect(() => {
     const adminData = localStorage.getItem("currentAdmin");
@@ -328,7 +332,9 @@ export default function AdminDashboard() {
         {/* Academic Weeks Settings */}
         <Card className="mb-6">
           <CardHeader>
-            <CardTitle className="text-orange-700">Academic Weeks Settings</CardTitle>
+            <CardTitle className="text-orange-700">
+              Academic Weeks Settings
+            </CardTitle>
           </CardHeader>
           <CardContent>
             <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 items-end">
@@ -340,7 +346,10 @@ export default function AdminDashboard() {
                   min={1}
                   value={totalWeeksInput}
                   onChange={(e) => {
-                    const val = Math.max(1, Math.floor(Number(e.target.value) || 0));
+                    const val = Math.max(
+                      1,
+                      Math.floor(Number(e.target.value) || 0),
+                    );
                     setTotalWeeksInput(val);
                     if (currentWeekInput > val) setCurrentWeekInput(val);
                   }}
@@ -357,7 +366,9 @@ export default function AdminDashboard() {
                   value={currentWeekInput}
                   onChange={(e) => {
                     const val = Math.floor(Number(e.target.value) || 1);
-                    setCurrentWeekInput(Math.min(Math.max(1, val), totalWeeksInput));
+                    setCurrentWeekInput(
+                      Math.min(Math.max(1, val), totalWeeksInput),
+                    );
                   }}
                   placeholder="Enter current week"
                 />
@@ -367,11 +378,16 @@ export default function AdminDashboard() {
                   className="bg-orange-600 hover:bg-orange-700 text-white"
                   onClick={() => {
                     const total = Math.max(1, Math.floor(totalWeeksInput || 0));
-                    const current = Math.min(Math.max(1, Math.floor(currentWeekInput || 1)), total);
+                    const current = Math.min(
+                      Math.max(1, Math.floor(currentWeekInput || 1)),
+                      total,
+                    );
                     updateWeeksSettings(current, total);
                     setTotalWeeksInput(total);
                     setCurrentWeekInput(current);
-                    showFeedback(`Saved: total weeks ${total}, current week ${current}`);
+                    showFeedback(
+                      `Saved: total weeks ${total}, current week ${current}`,
+                    );
                   }}
                 >
                   Save Settings

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -137,7 +137,7 @@ export default function Index() {
     );
   };
 
-  const weeks = Array.from({ length: 36 }, (_, i) => i + 1);
+  const weeks = Array.from({ length: currentData.totalWeeks }, (_, i) => i + 1);
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-purple-50 via-pink-50 to-yellow-50">
@@ -256,10 +256,10 @@ export default function Index() {
             <div className="w-24 sm:w-32 bg-gray-200 rounded-full h-2">
               <div
                 className="bg-gradient-to-r from-purple-500 to-pink-500 h-2 rounded-full"
-                style={{ width: `${(currentWeek / 36) * 100}%` }}
+                style={{ width: `${(currentWeek / currentData.totalWeeks) * 100}%` }}
               />
             </div>
-            <span>{Math.round((currentWeek / 36) * 100)}%</span>
+            <span>{Math.round((currentWeek / currentData.totalWeeks) * 100)}%</span>
           </div>
         </div>
 
@@ -268,7 +268,7 @@ export default function Index() {
           <div
             className="min-w-[4500px] grid gap-3"
             style={{
-              gridTemplateColumns: "160px repeat(36, minmax(120px, 1fr))",
+              gridTemplateColumns: `160px repeat(${currentData.totalWeeks}, minmax(120px, 1fr))`,
             }}
           >
             {" "}

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -256,10 +256,14 @@ export default function Index() {
             <div className="w-24 sm:w-32 bg-gray-200 rounded-full h-2">
               <div
                 className="bg-gradient-to-r from-purple-500 to-pink-500 h-2 rounded-full"
-                style={{ width: `${(currentWeek / currentData.totalWeeks) * 100}%` }}
+                style={{
+                  width: `${(currentWeek / currentData.totalWeeks) * 100}%`,
+                }}
               />
             </div>
-            <span>{Math.round((currentWeek / currentData.totalWeeks) * 100)}%</span>
+            <span>
+              {Math.round((currentWeek / currentData.totalWeeks) * 100)}%
+            </span>
           </div>
         </div>
 

--- a/client/pages/TeacherDashboard.tsx
+++ b/client/pages/TeacherDashboard.tsx
@@ -652,7 +652,7 @@ export default function TeacherDashboard() {
               </div>
               <div className="text-center p-4 bg-purple-50 rounded-lg">
                 <div className="text-2xl font-bold text-purple-600">
-                  {teacherSubjects.length * 36}
+                  {teacherSubjects.length * totalWeeks}
                 </div>
                 <div className="text-sm text-purple-700">Total Lessons</div>
               </div>

--- a/shared/data.ts
+++ b/shared/data.ts
@@ -307,7 +307,10 @@ const studentNames = [
   "Nathan Sanchez",
 ];
 
-const generateStudents = (currentWeek: number, totalWeeks: number): Student[] => {
+const generateStudents = (
+  currentWeek: number,
+  totalWeeks: number,
+): Student[] => {
   const students: Student[] = [];
 
   for (let i = 1; i <= 50; i++) {
@@ -333,15 +336,14 @@ const DEFAULT_CURRENT_WEEK = 12;
 const DEFAULT_TOTAL_WEEKS = 36;
 
 const loadedData = typeof window !== "undefined" ? DataStorage.load() : null;
-let globalVisionBoardData: VisionBoardData =
-  loadedData ?? {
-    students: generateStudents(DEFAULT_CURRENT_WEEK, DEFAULT_TOTAL_WEEKS),
-    subjects,
-    teachers,
-    admins,
-    currentWeek: DEFAULT_CURRENT_WEEK,
-    totalWeeks: DEFAULT_TOTAL_WEEKS,
-  };
+let globalVisionBoardData: VisionBoardData = loadedData ?? {
+  students: generateStudents(DEFAULT_CURRENT_WEEK, DEFAULT_TOTAL_WEEKS),
+  subjects,
+  teachers,
+  admins,
+  currentWeek: DEFAULT_CURRENT_WEEK,
+  totalWeeks: DEFAULT_TOTAL_WEEKS,
+};
 if (!loadedData && typeof window !== "undefined") {
   DataStorage.save(globalVisionBoardData);
 }

--- a/shared/data.ts
+++ b/shared/data.ts
@@ -91,12 +91,15 @@ const avatarColors = [
   "bg-teal-200",
 ];
 
-const generateMilestones = (studentId: string): Milestone[] => {
+const generateMilestones = (
+  studentId: string,
+  currentWeek: number,
+  totalWeeks: number,
+): Milestone[] => {
   const milestones: Milestone[] = [];
-  const currentWeek = 12; // Current week from visionBoardData
 
   subjects.forEach((subject) => {
-    for (let week = 1; week <= 36; week++) {
+    for (let week = 1; week <= totalWeeks; week++) {
       const id = `${studentId}-${subject.id}-${week}`;
       let attempts: QuizAttempt[] = [];
       let status: Milestone["status"] = "not-started";
@@ -304,12 +307,12 @@ const studentNames = [
   "Nathan Sanchez",
 ];
 
-const generateStudents = (): Student[] => {
+const generateStudents = (currentWeek: number, totalWeeks: number): Student[] => {
   const students: Student[] = [];
 
   for (let i = 1; i <= 50; i++) {
     const id = `student-${i}`;
-    const milestones = generateMilestones(id);
+    const milestones = generateMilestones(id, currentWeek, totalWeeks);
     const totalPoints = milestones.reduce((sum, m) => sum + m.points, 0);
 
     students.push({
@@ -326,15 +329,19 @@ const generateStudents = (): Student[] => {
 };
 
 // Create a global data store that can be updated
+const DEFAULT_CURRENT_WEEK = 12;
+const DEFAULT_TOTAL_WEEKS = 36;
+
 const loadedData = typeof window !== "undefined" ? DataStorage.load() : null;
-let globalVisionBoardData: VisionBoardData = loadedData ?? {
-  students: generateStudents(),
-  subjects,
-  teachers,
-  admins,
-  currentWeek: 12,
-  totalWeeks: 36,
-};
+let globalVisionBoardData: VisionBoardData =
+  loadedData ?? {
+    students: generateStudents(DEFAULT_CURRENT_WEEK, DEFAULT_TOTAL_WEEKS),
+    subjects,
+    teachers,
+    admins,
+    currentWeek: DEFAULT_CURRENT_WEEK,
+    totalWeeks: DEFAULT_TOTAL_WEEKS,
+  };
 if (!loadedData && typeof window !== "undefined") {
   DataStorage.save(globalVisionBoardData);
 }
@@ -625,4 +632,25 @@ export const getAdminByCredentials = (
 // Function to get current data (for React components to re-render)
 export const getCurrentVisionBoardData = (): VisionBoardData => {
   return { ...globalVisionBoardData };
+};
+
+export const updateWeeksSettings = (
+  newCurrentWeek: number,
+  newTotalWeeks: number,
+): boolean => {
+  const total = Math.max(1, Math.floor(newTotalWeeks || 0));
+  const current = Math.min(Math.max(1, Math.floor(newCurrentWeek || 1)), total);
+
+  globalVisionBoardData.totalWeeks = total;
+  globalVisionBoardData.currentWeek = current;
+
+  // Regenerate milestones for each student based on new settings
+  globalVisionBoardData.students = globalVisionBoardData.students.map((s) => {
+    const milestones = generateMilestones(s.id, current, total);
+    const totalPoints = milestones.reduce((sum, m) => sum + m.points, 0);
+    return { ...s, milestones, totalPoints };
+  });
+
+  if (typeof window !== "undefined") DataStorage.save(globalVisionBoardData);
+  return true;
 };

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -60,5 +60,5 @@ export interface VisionBoardData {
   teachers: Teacher[];
   admins: Admin[];
   currentWeek: number;
-  totalWeeks: 36;
+  totalWeeks: number;
 }


### PR DESCRIPTION
## Purpose

This PR adds administrative functionality to configure the educational year structure. The admin can now set the total number of weeks per academic year and the current week, with these settings persisted in browser local storage to maintain consistency across sessions.

## Code changes

- **Admin Dashboard**: Added new "Academic Weeks Settings" card with input fields for total weeks and current week, including validation and save functionality
- **Data layer**: Created `updateWeeksSettings()` function to update global settings and regenerate student milestones based on new week parameters
- **Dynamic week handling**: Replaced hardcoded 36-week values throughout the application with dynamic values from the current settings
- **Type updates**: Modified `VisionBoardData` interface to make `totalWeeks` a configurable number instead of fixed value
- **Progress calculations**: Updated progress bars and grid layouts to use dynamic week counts
- **Data persistence**: Settings are automatically saved to browser local storage when updatedTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 7`

🔗 [Edit in Builder.io](https://builder.io/app/projects/ecc013960cc04e62bab1cfae4fb8ca4d/zen-hub)

👀 [Preview Link](https://ecc013960cc04e62bab1cfae4fb8ca4d-zen-hub.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ecc013960cc04e62bab1cfae4fb8ca4d</projectId>-->
<!--<branchName>zen-hub</branchName>-->